### PR TITLE
Refactor warehouse role management and permissions

### DIFF
--- a/app/Http/Controllers/Estore/HomeController.php
+++ b/app/Http/Controllers/Estore/HomeController.php
@@ -133,13 +133,23 @@ class HomeController extends Controller
             $lat = $request->latitude;
             $lng = $request->longitude;
 
-            // Call Google Geocoding API
-            $apiKey = env('GOOGLE_MAPS_API_KEY');
-            $client = new Client();
-            $url = "https://maps.googleapis.com/maps/api/geocode/json?latlng={$lat},{$lng}&key={$apiKey}";
+            try {
+                // Call Google Geocoding API
+                $apiKey = env('GOOGLE_MAPS_API_KEY');
+                $client = new Client();
+                $url = "https://maps.googleapis.com/maps/api/geocode/json?latlng={$lat},{$lng}&key={$apiKey}";
 
-            $response = $client->get($url);
-            $data = json_decode($response->getBody(), true);
+                $response = $client->get($url);
+                //  return $response;
+                $data = json_decode($response->getBody(), true);
+
+                // if got any error from api then return
+                // if ($data['status'] !== 'OK') {
+                //     return response()->json(['success' => false, 'message' => 'Failed to retrieve address from coordinates'], 500);
+                // }
+            } catch (\Exception $e) {
+                return response()->json(['success' => false, 'message' => 'Error calling Geocoding API: ' . $e->getMessage()], 500);
+            }
 
             $address = null;
             $zip = null;
@@ -184,7 +194,14 @@ class HomeController extends Controller
                 session()->put('location_state', $state);
             }
 
-            return response()->json(['success' => true, 'message' => 'Location updated']);
+            return response()->json(['success' => true, 'message' => 'Location updated', 'location' => [
+                'latitude' => $lat,
+                'longitude' => $lng,
+                'address' => $address,
+                'zip' => $zip,
+                'country' => $country,
+                'state' => $state,
+            ]]);
         } catch (\Exception $e) {
             return response()->json(['success' => false, 'message' => $e->getMessage()], 500);
         }

--- a/app/Http/Controllers/User/WareHouseController.php
+++ b/app/Http/Controllers/User/WareHouseController.php
@@ -88,9 +88,9 @@ class WareHouseController extends Controller
                     $user = User::find($userId);
                     if ($user) {
                         $user->warehouses()->syncWithoutDetaching([$wareHouse->id]); // avoid duplicate attach
-                        if (!$user->hasRole('WAREHOUSE_ADMIN')) {
-                            $user->syncRoles(['WAREHOUSE_ADMIN']);
-                        }
+                        // if (!$user->hasRole('WAREHOUSE_ADMIN')) {
+                        //     $user->syncRoles(['WAREHOUSE_ADMIN']);
+                        // }
                     }
                 }
             }
@@ -174,9 +174,9 @@ class WareHouseController extends Controller
                 $user = User::find($userId);
                 if ($user) {
                     $user->warehouses()->syncWithoutDetaching([$wareHouse->id]);
-                    if (!$user->hasRole('WAREHOUSE_ADMIN')) {
-                        $user->syncRoles(['WAREHOUSE_ADMIN']);
-                    }
+                    // if (!$user->hasRole('WAREHOUSE_ADMIN')) {
+                    //     $user->syncRoles(['WAREHOUSE_ADMIN']);
+                    // }
                 }
             }
 
@@ -186,11 +186,11 @@ class WareHouseController extends Controller
                     $user->warehouses()->detach($wareHouse->id);
                     // if user has no more warehouses, remove warehouse admin role
                     if ($user->warehouses()->count() == 0) {
-                        if ($user->hasRole('WAREHOUSE_ADMIN')) {
-                            $user->removeRole('WAREHOUSE_ADMIN');
-                            // assign default role
-                            $user->syncRoles(['MEMBER_NON_SOVEREIGN']);
-                        }
+                        // if ($user->hasRole('WAREHOUSE_ADMIN')) {
+                        //     $user->removeRole('WAREHOUSE_ADMIN');
+                        //     // assign default role
+                        //     $user->syncRoles(['MEMBER_NON_SOVEREIGN']);
+                        // }
                     }
                 }
             }

--- a/app/Http/Controllers/User/WarehouseAdminController.php
+++ b/app/Http/Controllers/User/WarehouseAdminController.php
@@ -22,17 +22,19 @@ class WarehouseAdminController extends Controller
 {
     use ImageTrait;
 
+    public function __construct()
+    {
+        // Example: only admins can access this controller
+        if (!auth()->user()->hasRole('SUPER ADMIN') || !auth()->user()->hasRole('ADMINISTRATOR') || !auth()->user()->isWarehouseAdmin()) {
+            abort(403, 'Access denied.');
+        }
+    }
+
     /**
      * Display a listing of the warehouse admins.
      */
     public function index()
     {
-        // access blocked for now
-        abort(403, 'Unauthorized action.');
-
-        if (!auth()->user()->hasRole('SUPER ADMIN') || auth()->user()->hasRole('ADMINISTRATOR')) {
-            abort(403, 'Unauthorized action.');
-        }
 
         $warehouseAdmins = User::role('WAREHOUSE_ADMIN')->get();
         return view('user.warehouse-admin.list', compact('warehouseAdmins'));
@@ -43,12 +45,7 @@ class WarehouseAdminController extends Controller
      */
     public function create()
     {
-         // access blocked for now
-        abort(403, 'Unauthorized action.');
 
-        if (!auth()->user()->hasRole('SUPER ADMIN') || auth()->user()->hasRole('ADMINISTRATOR')) {
-            abort(403, 'Unauthorized action.');
-        }
 
         $warehouses = WareHouse::where('is_active', 1)->get();
         return view('user.warehouse-admin.create', compact('warehouses'));
@@ -59,12 +56,7 @@ class WarehouseAdminController extends Controller
      */
     public function store(Request $request)
     {
-         // access blocked for now
-        abort(403, 'Unauthorized action.');
 
-        if (!auth()->user()->hasRole('SUPER ADMIN') || auth()->user()->hasRole('ADMINISTRATOR')) {
-            abort(403, 'Unauthorized action.');
-        }
 
         $request->validate([
             'user_name' => 'required|string|max:255|unique:users',
@@ -109,12 +101,7 @@ class WarehouseAdminController extends Controller
      */
     public function show($id)
     {
-         // access blocked for now
-        abort(403, 'Unauthorized action.');
 
-        if (!auth()->user()->hasRole('SUPER ADMIN') || auth()->user()->hasRole('ADMINISTRATOR')) {
-            abort(403, 'Unauthorized action.');
-        }
 
         $warehouseAdmin = User::role('WAREHOUSE_ADMIN')->findOrFail($id);
         return view('user.warehouse-admin.show', compact('warehouseAdmin'));
@@ -125,12 +112,7 @@ class WarehouseAdminController extends Controller
      */
     public function edit($id)
     {
-         // access blocked for now
-        abort(403, 'Unauthorized action.');
 
-        if (!auth()->user()->hasRole('SUPER ADMIN') || auth()->user()->hasRole('ADMINISTRATOR')) {
-            abort(403, 'Unauthorized action.');
-        }
 
         $warehouseAdmin = User::role('WAREHOUSE_ADMIN')->findOrFail($id);
         $warehouses = WareHouse::where('is_active', 1)->get();
@@ -144,12 +126,7 @@ class WarehouseAdminController extends Controller
      */
     public function update(Request $request, $id)
     {
-         // access blocked for now
-        abort(403, 'Unauthorized action.');
 
-        if (!auth()->user()->hasRole('SUPER ADMIN') || auth()->user()->hasRole('ADMINISTRATOR')) {
-            abort(403, 'Unauthorized action.');
-        }
 
         $warehouseAdmin = User::role('WAREHOUSE_ADMIN')->findOrFail($id);
 
@@ -191,12 +168,7 @@ class WarehouseAdminController extends Controller
      */
     public function destroy($id)
     {
-         // access blocked for now
-        abort(403, 'Unauthorized action.');
 
-        if (!auth()->user()->hasRole('SUPER ADMIN') || auth()->user()->hasRole('ADMINISTRATOR')) {
-            abort(403, 'Unauthorized action.');
-        }
 
         $warehouseAdmin = User::role('WAREHOUSE_ADMIN')->findOrFail($id);
 
@@ -218,12 +190,7 @@ class WarehouseAdminController extends Controller
      */
     public function delete($id)
     {
-         // access blocked for now
-        abort(403, 'Unauthorized action.');
 
-        if (!auth()->user()->hasRole('SUPER ADMIN') || auth()->user()->hasRole('ADMINISTRATOR')) {
-            abort(403, 'Unauthorized action.');
-        }
 
         $warehouseAdmin = User::role('WAREHOUSE_ADMIN')->findOrFail($id);
 
@@ -246,9 +213,7 @@ class WarehouseAdminController extends Controller
      */
     public function listProducts()
     {
-        if (!auth()->user()->isWarehouseAdmin()) {
-            abort(403, 'Unauthorized action.');
-        }
+
 
         // Get warehouse IDs that this admin can manage
         $warehouseIds = auth()->user()->warehouses->pluck('id')->toArray();
@@ -266,9 +231,7 @@ class WarehouseAdminController extends Controller
      */
     public function createProduct()
     {
-        if (!auth()->user()->isWarehouseAdmin()) {
-            abort(403, 'Unauthorized action.');
-        }
+
 
         $categories = Category::where('status', 1)->get();
         $sizes = Size::where('status', 1)->get();
@@ -283,9 +246,7 @@ class WarehouseAdminController extends Controller
      */
     public function storeProduct(Request $request)
     {
-        if (!auth()->user()->isWarehouseAdmin()) {
-            abort(403, 'Unauthorized action.');
-        }
+
 
         $request->validate([
             'category_id' => 'required|exists:categories,id',
@@ -377,9 +338,7 @@ class WarehouseAdminController extends Controller
      */
     public function editProduct($id)
     {
-        if (!auth()->user()->isWarehouseAdmin()) {
-            abort(403, 'Unauthorized action.');
-        }
+
 
         $product = Product::findOrFail($id);
 
@@ -409,9 +368,7 @@ class WarehouseAdminController extends Controller
      */
     public function updateProduct(Request $request, $id)
     {
-        if (!auth()->user()->isWarehouseAdmin()) {
-            abort(403, 'Unauthorized action.');
-        }
+
 
         $product = Product::findOrFail($id);
 
@@ -536,9 +493,7 @@ class WarehouseAdminController extends Controller
      */
     public function deleteProduct($id)
     {
-        if (!auth()->user()->isWarehouseAdmin()) {
-            abort(403, 'Unauthorized action.');
-        }
+
 
         $product = Product::findOrFail($id);
 
@@ -568,9 +523,7 @@ class WarehouseAdminController extends Controller
      */
     public function listSizes()
     {
-        if (!auth()->user()->isWarehouseAdmin()) {
-            abort(403, 'Unauthorized action.');
-        }
+
 
         $sizes = Size::paginate(10);
         return view('user.warehouse-admin.sizes.list', compact('sizes'));
@@ -581,9 +534,7 @@ class WarehouseAdminController extends Controller
      */
     public function createSize()
     {
-        if (!auth()->user()->isWarehouseAdmin()) {
-            abort(403, 'Unauthorized action.');
-        }
+
 
         return view('user.warehouse-admin.sizes.create');
     }
@@ -593,9 +544,7 @@ class WarehouseAdminController extends Controller
      */
     public function storeSize(Request $request)
     {
-        if (!auth()->user()->isWarehouseAdmin()) {
-            abort(403, 'Unauthorized action.');
-        }
+
 
         $request->validate([
             'name' => 'required|string|max:255|unique:sizes,size',
@@ -615,9 +564,7 @@ class WarehouseAdminController extends Controller
      */
     public function editSize($id)
     {
-        if (!auth()->user()->isWarehouseAdmin()) {
-            abort(403, 'Unauthorized action.');
-        }
+
 
         $size = Size::findOrFail($id);
         return view('user.warehouse-admin.sizes.edit', compact('size'));
@@ -628,9 +575,7 @@ class WarehouseAdminController extends Controller
      */
     public function updateSize(Request $request, $id)
     {
-        if (!auth()->user()->isWarehouseAdmin()) {
-            abort(403, 'Unauthorized action.');
-        }
+
 
         $size = Size::findOrFail($id);
 
@@ -652,9 +597,7 @@ class WarehouseAdminController extends Controller
      */
     public function deleteSize($id)
     {
-        if (!auth()->user()->isWarehouseAdmin()) {
-            abort(403, 'Unauthorized action.');
-        }
+
 
         $size = Size::findOrFail($id);
 
@@ -680,9 +623,7 @@ class WarehouseAdminController extends Controller
      */
     public function listColors()
     {
-        if (!auth()->user()->isWarehouseAdmin()) {
-            abort(403, 'Unauthorized action.');
-        }
+
 
         $colors = Color::paginate(10);
         return view('user.warehouse-admin.colors.list', compact('colors'));
@@ -693,9 +634,7 @@ class WarehouseAdminController extends Controller
      */
     public function createColor()
     {
-        if (!auth()->user()->isWarehouseAdmin()) {
-            abort(403, 'Unauthorized action.');
-        }
+
 
         return view('user.warehouse-admin.colors.create');
     }
@@ -705,9 +644,7 @@ class WarehouseAdminController extends Controller
      */
     public function storeColor(Request $request)
     {
-        if (!auth()->user()->isWarehouseAdmin()) {
-            abort(403, 'Unauthorized action.');
-        }
+
 
         $request->validate([
             'color_name' => 'required|string|max:255|unique:colors,color_name',
@@ -729,9 +666,7 @@ class WarehouseAdminController extends Controller
      */
     public function editColor($id)
     {
-        if (!auth()->user()->isWarehouseAdmin()) {
-            abort(403, 'Unauthorized action.');
-        }
+
 
         $color = Color::findOrFail($id);
         return view('user.warehouse-admin.colors.edit', compact('color'));
@@ -742,9 +677,7 @@ class WarehouseAdminController extends Controller
      */
     public function updateColor(Request $request, $id)
     {
-        if (!auth()->user()->isWarehouseAdmin()) {
-            abort(403, 'Unauthorized action.');
-        }
+
 
         $color = Color::findOrFail($id);
 
@@ -768,9 +701,7 @@ class WarehouseAdminController extends Controller
      */
     public function deleteColor($id)
     {
-        if (!auth()->user()->isWarehouseAdmin()) {
-            abort(403, 'Unauthorized action.');
-        }
+
 
         $color = Color::findOrFail($id);
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -161,7 +161,9 @@ class User extends Authenticatable
     // Check if user is a warehouse admin
     public function isWarehouseAdmin()
     {
-        return $this->hasRole('WAREHOUSE_ADMIN');
+       // return $this->hasRole('WAREHOUSE_ADMIN');
+       // check if user has any warehouses assigned
+       return $this->warehouses()->exists();
     }
 
     // Check if user can manage a specific warehouse

--- a/database/seeders/RemoveWareHouseRolePermissionSeeder.php
+++ b/database/seeders/RemoveWareHouseRolePermissionSeeder.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Spatie\Permission\Models\Role;
+use Spatie\Permission\Models\Permission;
+
+class RemoveWareHouseRolePermissionSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        //
+        $roles = Role::where('name', 'WAREHOUSE_ADMIN')->get();
+        foreach ($roles as $role) {
+            $role->permissions()->detach();
+        }
+        // delete the role
+        Role::where('name', 'WAREHOUSE_ADMIN')->delete();
+    }
+}

--- a/resources/views/ecom/includes/header.blade.php
+++ b/resources/views/ecom/includes/header.blade.php
@@ -406,7 +406,7 @@
                             var locationModal = bootstrap.Modal.getInstance(document
                                 .getElementById('locationModal'));
                             locationModal.hide();
-                            window.location.reload();
+                            //  window.location.reload();
                         },
                         error: function(xhr) {
                             console.error("Error:", xhr.responseText);

--- a/resources/views/user/includes/sidebar.blade.php
+++ b/resources/views/user/includes/sidebar.blade.php
@@ -378,7 +378,7 @@
                     </li>
                 @endif
 
-                @if (Auth::user()->hasRole('WAREHOUSE_ADMIN'))
+                @if (Auth::user()->warehouses->count() > 0)
                     <li class="sidebar-item">
                         <a class="sidebar-link" href="#" aria-expanded="false" data-bs-toggle="collapse"
                             data-bs-target="#collapseExample10">

--- a/resources/views/user/partner/list.blade.php
+++ b/resources/views/user/partner/list.blade.php
@@ -58,6 +58,7 @@
                                                 </th>
                                                 <th class="p-3">Role</th>
                                                 <th class="p-3">House Of Ecclesia</th>
+                                                <th class="p-3">Manage Warehouses</th>
 
                                                 {{-- <th>
                                                     Ecclesia

--- a/resources/views/user/partner/table.blade.php
+++ b/resources/views/user/partner/table.blade.php
@@ -10,8 +10,7 @@
                 <span>{{ $partner->getRoleNames()->first() }}</span>
 
                 @if ($partner->is_ecclesia_admin == 1)
-
-                {{-- @dd($partner) --}}
+                    {{-- @dd($partner) --}}
                     <br>
 
                     <button title="Ecclesia Access" type="button" class="btn btn-primary btn-sm ecclesia-see-button"
@@ -47,13 +46,11 @@
                                 </div>
                                 <div class="modal-footer">
                                     @if (auth()->user()->can('Edit Partners'))
-                                        {{-- @if (auth()->user()->hasRole('SUPER ADMIN') ||
-                                                $partner->created_id == auth()->user()->id ||
-                                                (auth()->user()->roles()->first()->is_ecclesia == 1 && auth()->id() != $partner->id)) --}}
-                                            <a href="{{ route('partners.edit', Crypt::encrypt($partner->id)) }}"
-                                                type="button" class="btn btn-primary me-3">
-                                                Edit Member
-                                            </a>
+                                        {{-- @if (auth()->user()->hasRole('SUPER ADMIN') || $partner->created_id == auth()->user()->id || (auth()->user()->roles()->first()->is_ecclesia == 1 && auth()->id() != $partner->id)) --}}
+                                        <a href="{{ route('partners.edit', Crypt::encrypt($partner->id)) }}"
+                                            type="button" class="btn btn-primary me-3">
+                                            Edit Member
+                                        </a>
                                         {{-- @endif --}}
                                     @endif
                                     <button type="button" class="btn btn-primary" data-bs-dismiss="modal">
@@ -69,6 +66,23 @@
 
             <td>
                 {{ isset($partner->ecclesia) ? $partner->ecclesia->name . ' (' . $partner->ecclesia->countryName->name . ')' : 'NO NAME' }}
+            </td>
+            <td>
+
+                @if ($partner->warehouses->count() > 0)
+                    <br>
+                    <ul>
+                        @foreach ($partner->warehouses as $warehouse)
+                            <li>
+                                {{ $warehouse->name }}
+                                @if (!$loop->last)
+                                    ,
+                                @endif
+
+                            </li>
+                        @endforeach
+                    </ul>
+                @endif
             </td>
             {{-- <td>{{ $partner->user_name }}</td>
 
@@ -102,13 +116,11 @@
                 <td>
                     <div class="d-flex">
                         @if (Auth::user()->can('Edit Partners'))
-                            {{-- @if (auth()->user()->hasRole('SUPER ADMIN') ||
-                                    $partner->created_id == auth()->user()->id ||
-                                    (auth()->user()->roles()->first()->is_ecclesia == 1 && auth()->id() != $partner->id)) --}}
-                                <a href="{{ route('partners.edit', Crypt::encrypt($partner->id)) }}"
-                                    class="edit_icon me-2">
-                                    <i class="ti ti-edit"></i>
-                                </a>
+                            {{-- @if (auth()->user()->hasRole('SUPER ADMIN') || $partner->created_id == auth()->user()->id || (auth()->user()->roles()->first()->is_ecclesia == 1 && auth()->id() != $partner->id)) --}}
+                            <a href="{{ route('partners.edit', Crypt::encrypt($partner->id)) }}"
+                                class="edit_icon me-2">
+                                <i class="ti ti-edit"></i>
+                            </a>
                             {{-- @endif --}}
                         @endif
 
@@ -119,14 +131,12 @@
                             </a>
                         @endif
                         @if (Auth::user()->can('Delete Partners'))
-                            {{-- @if (auth()->user()->hasRole('SUPER ADMIN') ||
-                                    $partner->created_id == auth()->user()->id ||
-                                    (auth()->user()->roles()->first()->is_ecclesia == 1 && auth()->id() != $partner->id)) --}}
-                                <a href="javascript:void(0);"
-                                    data-route="{{ route('partners.delete', Crypt::encrypt($partner->id)) }}"
-                                    class="delete_icon" id="delete">
-                                    <i class="ti ti-trash"></i>
-                                </a>
+                            {{-- @if (auth()->user()->hasRole('SUPER ADMIN') || $partner->created_id == auth()->user()->id || (auth()->user()->roles()->first()->is_ecclesia == 1 && auth()->id() != $partner->id)) --}}
+                            <a href="javascript:void(0);"
+                                data-route="{{ route('partners.delete', Crypt::encrypt($partner->id)) }}"
+                                class="delete_icon" id="delete">
+                                <i class="ti ti-trash"></i>
+                            </a>
                             {{-- @endif --}}
                         @endif
 

--- a/resources/views/user/product/create.blade.php
+++ b/resources/views/user/product/create.blade.php
@@ -392,7 +392,7 @@
                                                 <div class="box_label">
                                                     <label>Warehouse <span class="text-danger">*</span></label>
                                                     <select name="warehouse_products[0][warehouse_id]"
-                                                        class="form-control warehouse-id" required>
+                                                        class="form-control warehouse-id" >
                                                         <option value="">Select Warehouse</option>
                                                         @foreach ($warehouses as $warehouse)
                                                             <option value="{{ $warehouse->id }}">{{ $warehouse->name }}
@@ -406,7 +406,7 @@
                                                 <div class="box_label">
                                                     <label>SKU <span class="text-danger">*</span></label>
                                                     <input type="text" name="warehouse_products[0][sku]"
-                                                        class="form-control" required>
+                                                        class="form-control" >
                                                 </div>
                                             </div>
 
@@ -414,7 +414,7 @@
                                                 <div class="box_label">
                                                     <label>Price <span class="text-danger">*</span></label>
                                                     <input type="number" step="0.01"
-                                                        name="warehouse_products[0][price]" class="form-control" required>
+                                                        name="warehouse_products[0][price]" class="form-control" >
                                                 </div>
                                             </div>
 
@@ -448,7 +448,7 @@
                                                 <div class="box_label">
                                                     <label>Images <span class="text-danger">*</span></label>
                                                     <input type="file" name="warehouse_products[0][images][]"
-                                                        class="form-control" multiple required>
+                                                        class="form-control" multiple >
                                                 </div>
                                             </div>
 
@@ -459,7 +459,7 @@
                                                     <label>Quantity <span class="text-danger">*</span></label>
                                                     <input type="number" min="0"
                                                         name="warehouse_products[0][quantity]" class="form-control"
-                                                        required>
+                                                        >
                                                 </div>
                                             </div>
 
@@ -672,7 +672,7 @@
                             <div class="col-md-4 mb-2">
                                 <div class="box_label">
                                     <label>Warehouse <span class="text-danger">*</span></label>
-                                    <select name="warehouse_products[${warehouseProductIndex}][warehouse_id]" class="form-control warehouse-id" required>
+                                    <select name="warehouse_products[${warehouseProductIndex}][warehouse_id]" class="form-control warehouse-id" >
                                         <option value="">Select Warehouse</option>
                                         @foreach ($warehouses as $warehouse)
                                             <option value="{{ $warehouse->id }}">{{ $warehouse->name }}</option>
@@ -684,14 +684,14 @@
                             <div class="col-md-4 mb-2">
                                 <div class="box_label">
                                     <label>SKU <span class="text-danger">*</span></label>
-                                    <input type="text" name="warehouse_products[${warehouseProductIndex}][sku]" class="form-control" required>
+                                    <input type="text" name="warehouse_products[${warehouseProductIndex}][sku]" class="form-control" >
                                 </div>
                             </div>
 
                             <div class="col-md-4 mb-2">
                                 <div class="box_label">
                                     <label>Price <span class="text-danger">*</span></label>
-                                    <input type="number" step="0.01" name="warehouse_products[${warehouseProductIndex}][price]" class="form-control" required>
+                                    <input type="number" step="0.01" name="warehouse_products[${warehouseProductIndex}][price]" class="form-control" >
                                 </div>
                             </div>
 
@@ -723,7 +723,7 @@
                                         <div class="box_label">
                                             <label>Images <span class="text-danger">*</span></label>
                                             <input type="file" name="warehouse_products[${warehouseProductIndex}][images][]"
-                                                class="form-control" multiple required>
+                                                class="form-control" multiple >
                                         </div>
                                     </div>
 
@@ -732,7 +732,7 @@
                             <div class="col-md-2 mb-2">
                                 <div class="box_label">
                                     <label>Quantity <span class="text-danger">*</span></label>
-                                    <input type="number" min="0" name="warehouse_products[${warehouseProductIndex}][quantity]" class="form-control" required>
+                                    <input type="number" min="0" name="warehouse_products[${warehouseProductIndex}][quantity]" class="form-control" >
                                 </div>
                             </div>
 

--- a/resources/views/user/product/edit.blade.php
+++ b/resources/views/user/product/edit.blade.php
@@ -485,7 +485,7 @@
                                     @endif
                                 </div>
                             </div>
-                            <div class="tab-pane fade" id="variation" role="tabpanel" aria-labelledby="variation-tab">
+                            <div class="tab-pane fade" id="variation" role="tabpanel" aria-labelledby="variation">
                                 <!-- Warehouse Products Section -->
                                 <div class="row mt-3">
                                     <div class="col-md-12">
@@ -505,7 +505,7 @@
                                                             <label>Warehouse <span class="text-danger">*</span></label>
                                                             <select
                                                                 name="warehouse_products[{{ $index }}][warehouse_id]"
-                                                                class="form-control warehouse-id" required>
+                                                                class="form-control warehouse-id">
                                                                 <option value="">Select Warehouse</option>
                                                                 @foreach ($warehouses as $warehouse)
                                                                     <option value="{{ $warehouse->id }}"
@@ -525,8 +525,8 @@
                                                             <label>SKU <span class="text-danger">*</span></label>
                                                             <input type="text"
                                                                 name="warehouse_products[{{ $index }}][sku]"
-                                                                class="form-control" value="{{ $warehouseProduct->sku }}"
-                                                                required>
+                                                                class="form-control"
+                                                                value="{{ $warehouseProduct->sku }}">
                                                         </div>
                                                     </div>
 
@@ -536,7 +536,7 @@
                                                             <input type="number" step="0.01"
                                                                 name="warehouse_products[{{ $index }}][price]"
                                                                 class="form-control"
-                                                                value="{{ $warehouseProduct->price }}" required>
+                                                                value="{{ $warehouseProduct->price }}">
                                                         </div>
                                                     </div>
 
@@ -616,7 +616,7 @@
                                                             <input type="number" min="0"
                                                                 name="warehouse_products[{{ $index }}][quantity]"
                                                                 class="form-control"
-                                                                value="{{ $warehouseProduct->quantity }}" required>
+                                                                value="{{ $warehouseProduct->quantity }}">
                                                         </div>
                                                     </div>
 
@@ -636,7 +636,7 @@
                                                     <div class="box_label">
                                                         <label>Warehouse <span class="text-danger">*</span></label>
                                                         <select name="warehouse_products[0][warehouse_id]"
-                                                            class="form-control warehouse-id" required>
+                                                            class="form-control warehouse-id">
                                                             <option value="">Select Warehouse</option>
                                                             @foreach ($warehouses as $warehouse)
                                                                 <option value="{{ $warehouse->id }}">
@@ -651,7 +651,7 @@
                                                     <div class="box_label">
                                                         <label>SKU <span class="text-danger">*</span></label>
                                                         <input type="text" name="warehouse_products[0][sku]"
-                                                            class="form-control" required>
+                                                            class="form-control">
                                                     </div>
                                                 </div>
 
@@ -659,8 +659,7 @@
                                                     <div class="box_label">
                                                         <label>Price <span class="text-danger">*</span></label>
                                                         <input type="number" step="0.01"
-                                                            name="warehouse_products[0][price]" class="form-control"
-                                                            required>
+                                                            name="warehouse_products[0][price]" class="form-control">
                                                     </div>
                                                 </div>
 
@@ -707,8 +706,7 @@
                                                     <div class="box_label">
                                                         <label>Quantity <span class="text-danger">*</span></label>
                                                         <input type="number" min="0"
-                                                            name="warehouse_products[0][quantity]" class="form-control"
-                                                            required>
+                                                            name="warehouse_products[0][quantity]" class="form-control">
                                                     </div>
                                                 </div>
 
@@ -974,7 +972,7 @@
                             <div class="col-md-4 mb-2">
                                 <div class="box_label">
                                     <label>Warehouse <span class="text-danger">*</span></label>
-                                    <select name="warehouse_products[${warehouseProductIndex}][warehouse_id]" class="form-control warehouse-id" required>
+                                    <select name="warehouse_products[${warehouseProductIndex}][warehouse_id]" class="form-control warehouse-id" >
                                         <option value="">Select Warehouse</option>
                                         @foreach ($warehouses as $warehouse)
                                             <option value="{{ $warehouse->id }}">{{ $warehouse->name }}</option>
@@ -986,14 +984,14 @@
                             <div class="col-md-4 mb-2">
                                 <div class="box_label">
                                     <label>SKU <span class="text-danger">*</span></label>
-                                    <input type="text" name="warehouse_products[${warehouseProductIndex}][sku]" class="form-control" required>
+                                    <input type="text" name="warehouse_products[${warehouseProductIndex}][sku]" class="form-control" >
                                 </div>
                             </div>
 
                             <div class="col-md-4 mb-2">
                                 <div class="box_label">
                                     <label>Price <span class="text-danger">*</span></label>
-                                    <input type="number" step="0.01" name="warehouse_products[${warehouseProductIndex}][price]" class="form-control" required>
+                                    <input type="number" step="0.01" name="warehouse_products[${warehouseProductIndex}][price]" class="form-control" >
                                 </div>
                             </div>
 
@@ -1034,7 +1032,7 @@
                             <div class="col-md-2 mb-2">
                                 <div class="box_label">
                                     <label>Quantity <span class="text-danger">*</span></label>
-                                    <input type="number" min="0" name="warehouse_products[${warehouseProductIndex}][quantity]" class="form-control" required>
+                                    <input type="number" min="0" name="warehouse_products[${warehouseProductIndex}][quantity]" class="form-control" >
                                 </div>
                             </div>
 
@@ -1053,6 +1051,23 @@
                 $(document).on('click', '.remove-warehouse-product', function() {
                     $(this).closest('.warehouse-product-entry').remove();
                 });
+            });
+        </script>
+
+        <script>
+            $(document).ready(function() {
+                // if url has ?tab=variations, open that tab (Bootstrap 5)
+                const urlParams = new URLSearchParams(window.location.search);
+                const tab = urlParams.get('tab');
+                if (tab === 'variations') {
+                    // Use Bootstrap 5 Tab API to show the variation tab
+                    const variationTrigger = document.querySelector('#variation-tab');
+                    if (variationTrigger && typeof bootstrap !== 'undefined' && bootstrap.Tab) {
+                        const tabInstance = bootstrap.Tab.getInstance(variationTrigger) || new bootstrap.Tab(
+                            variationTrigger);
+                        tabInstance.show();
+                    }
+                }
             });
         </script>
     @endpush

--- a/resources/views/user/product/list.blade.php
+++ b/resources/views/user/product/list.blade.php
@@ -52,10 +52,10 @@
                                                     style="cursor: pointer">Product Slug <span id="slug_icon"><i
                                                             class="fa fa-arrow-down"></i></span></th>
                                                 {{-- price --}}
-                                                <th class="sorting" data-tippy-content="Sort by Product Price"
+                                                {{-- <th class="sorting" data-tippy-content="Sort by Product Price"
                                                     data-sorting_type="desc" data-column_name="price"
                                                     style="cursor: pointer">Product Price <span id="price_icon"><i
-                                                            class="fa fa-arrow-down"></i></span></th>
+                                                            class="fa fa-arrow-down"></i></span></th> --}}
                                                 {{-- quantity --}}
                                                 {{-- <th class="sorting" data-tippy-content="Sort by Product Quantity"
                                                     data-sorting_type="desc" data-column_name="quantity"

--- a/resources/views/user/product/table.blade.php
+++ b/resources/views/user/product/table.blade.php
@@ -14,7 +14,7 @@
 
             <td> {{ $product->category ? $product->category->name : '' }}</td>
             <td> {{ $product->slug }}</td>
-            <td> {{ $product->price ? '$' . $product->price : '' }}</td>
+            {{-- <td> {{ $product->price ? '$' . $product->price : '' }}</td> --}}
             {{-- <td> {{ $product->sku }}</td>  --}}
             {{-- <td> {{ $product->affiliate_link }}</td> --}}
             {{-- status --}}
@@ -38,6 +38,9 @@
                 <div class="d-flex">
                     <a href="{{ route('products.edit', $product->id) }}" class="delete_icon">
                         <i class="fa-solid fa-edit"></i>
+                    </a> &nbsp; &nbsp;
+                    <a href="{{ route('products.edit', $product->id) . '?tab=variations' }}" class="delete_icon">
+                        <i class="fa-solid fa-th"></i>
                     </a> &nbsp; &nbsp;
                     <a href="javascript:void(0)" id="delete"
                         data-route="{{ route('products.delete', $product->id) }}" class="delete_icon">

--- a/resources/views/user/role_permission/list.blade.php
+++ b/resources/views/user/role_permission/list.blade.php
@@ -11,14 +11,14 @@
                 <div class="row">
                     <div class="col-lg-12">
                         <div class="row">
-                            <div class="col-md-12">
+                            <div class="col-lg-12">
 
                                 <div class="row justify-content-between">
-                                    <div class="col-md-2">
+                                    <div class="col-lg-8">
                                         <h3 class="mb-3">Role Permission List</h3>
                                     </div>
 
-                                    <div class="col-md-4 text-end">
+                                    <div class="col-lg-4 text-end">
                                         <a href="{{ route('ecclesias.index') }}" class="btn btn-primary me-3">+
                                             House Of Ecclesia</a>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -534,28 +534,28 @@ Route::prefix('user')->middleware(['user', 'preventBackHistory'])->group(functio
     Route::get('/warehouse-admins-delete/{id}', [WarehouseAdminController::class, 'delete'])->name('warehouse-admins.delete');
 
     // Warehouse Admin Product Management Routes (new)
-    Route::get('/warehouse-products', [WarehouseAdminController::class, 'listProducts'])->name('warehouse-admin.products')->middleware('role:WAREHOUSE_ADMIN');
-    Route::get('/warehouse-products/create', [WarehouseAdminController::class, 'createProduct'])->name('warehouse-admin.products.create')->middleware('role:WAREHOUSE_ADMIN');
-    Route::post('/warehouse-products', [WarehouseAdminController::class, 'storeProduct'])->name('warehouse-admin.products.store')->middleware('role:WAREHOUSE_ADMIN');
-    Route::get('/warehouse-products/{id}/edit', [WarehouseAdminController::class, 'editProduct'])->name('warehouse-admin.products.edit')->middleware('role:WAREHOUSE_ADMIN');
-    Route::put('/warehouse-products/{id}', [WarehouseAdminController::class, 'updateProduct'])->name('warehouse-admin.products.update')->middleware('role:WAREHOUSE_ADMIN');
-    Route::get('/warehouse-products/{id}/delete', [WarehouseAdminController::class, 'deleteProduct'])->name('warehouse-admin.products.delete')->middleware('role:WAREHOUSE_ADMIN');
+    Route::get('/warehouse-products', [WarehouseAdminController::class, 'listProducts'])->name('warehouse-admin.products');
+    Route::get('/warehouse-products/create', [WarehouseAdminController::class, 'createProduct'])->name('warehouse-admin.products.create');
+    Route::post('/warehouse-products', [WarehouseAdminController::class, 'storeProduct'])->name('warehouse-admin.products.store');
+    Route::get('/warehouse-products/{id}/edit', [WarehouseAdminController::class, 'editProduct'])->name('warehouse-admin.products.edit');
+    Route::put('/warehouse-products/{id}', [WarehouseAdminController::class, 'updateProduct'])->name('warehouse-admin.products.update');
+    Route::get('/warehouse-products/{id}/delete', [WarehouseAdminController::class, 'deleteProduct'])->name('warehouse-admin.products.delete');
 
     // Warehouse Admin Size Management Routes (new)
-    Route::get('/warehouse-sizes', [WarehouseAdminController::class, 'listSizes'])->name('warehouse-admin.sizes')->middleware('role:WAREHOUSE_ADMIN');
-    Route::get('/warehouse-sizes/create', [WarehouseAdminController::class, 'createSize'])->name('warehouse-admin.sizes.create')->middleware('role:WAREHOUSE_ADMIN');
-    Route::post('/warehouse-sizes', [WarehouseAdminController::class, 'storeSize'])->name('warehouse-admin.sizes.store')->middleware('role:WAREHOUSE_ADMIN');
-    Route::get('/warehouse-sizes/{id}/edit', [WarehouseAdminController::class, 'editSize'])->name('warehouse-admin.sizes.edit')->middleware('role:WAREHOUSE_ADMIN');
-    Route::put('/warehouse-sizes/{id}', [WarehouseAdminController::class, 'updateSize'])->name('warehouse-admin.sizes.update')->middleware('role:WAREHOUSE_ADMIN');
-    Route::get('/warehouse-sizes/{id}/delete', [WarehouseAdminController::class, 'deleteSize'])->name('warehouse-admin.sizes.delete')->middleware('role:WAREHOUSE_ADMIN');
+    Route::get('/warehouse-sizes', [WarehouseAdminController::class, 'listSizes'])->name('warehouse-admin.sizes');
+    Route::get('/warehouse-sizes/create', [WarehouseAdminController::class, 'createSize'])->name('warehouse-admin.sizes.create');
+    Route::post('/warehouse-sizes', [WarehouseAdminController::class, 'storeSize'])->name('warehouse-admin.sizes.store');
+    Route::get('/warehouse-sizes/{id}/edit', [WarehouseAdminController::class, 'editSize'])->name('warehouse-admin.sizes.edit');
+    Route::put('/warehouse-sizes/{id}', [WarehouseAdminController::class, 'updateSize'])->name('warehouse-admin.sizes.update');
+    Route::get('/warehouse-sizes/{id}/delete', [WarehouseAdminController::class, 'deleteSize'])->name('warehouse-admin.sizes.delete');
 
     // Warehouse Admin Color Management Routes (new)
-    Route::get('/warehouse-colors', [WarehouseAdminController::class, 'listColors'])->name('warehouse-admin.colors')->middleware('role:WAREHOUSE_ADMIN');
-    Route::get('/warehouse-colors/create', [WarehouseAdminController::class, 'createColor'])->name('warehouse-admin.colors.create')->middleware('role:WAREHOUSE_ADMIN');
-    Route::post('/warehouse-colors', [WarehouseAdminController::class, 'storeColor'])->name('warehouse-admin.colors.store')->middleware('role:WAREHOUSE_ADMIN');
-    Route::get('/warehouse-colors/{id}/edit', [WarehouseAdminController::class, 'editColor'])->name('warehouse-admin.colors.edit')->middleware('role:WAREHOUSE_ADMIN');
-    Route::put('/warehouse-colors/{id}', [WarehouseAdminController::class, 'updateColor'])->name('warehouse-admin.colors.update')->middleware('role:WAREHOUSE_ADMIN');
-    Route::get('/warehouse-colors/{id}/delete', [WarehouseAdminController::class, 'deleteColor'])->name('warehouse-admin.colors.delete')->middleware('role:WAREHOUSE_ADMIN');
+    Route::get('/warehouse-colors', [WarehouseAdminController::class, 'listColors'])->name('warehouse-admin.colors');
+    Route::get('/warehouse-colors/create', [WarehouseAdminController::class, 'createColor'])->name('warehouse-admin.colors.create');
+    Route::post('/warehouse-colors', [WarehouseAdminController::class, 'storeColor'])->name('warehouse-admin.colors.store');
+    Route::get('/warehouse-colors/{id}/edit', [WarehouseAdminController::class, 'editColor'])->name('warehouse-admin.colors.edit');
+    Route::put('/warehouse-colors/{id}', [WarehouseAdminController::class, 'updateColor'])->name('warehouse-admin.colors.update');
+    Route::get('/warehouse-colors/{id}/delete', [WarehouseAdminController::class, 'deleteColor'])->name('warehouse-admin.colors.delete');
 
     Route::get('/estore-users-list', [PartnerController::class, 'estoreUsers'])->name('estore-users.list');
     // estore-users.fetch-data


### PR DESCRIPTION
- Removed role assignment for 'WAREHOUSE_ADMIN' in WareHouseController.
- Updated WarehouseAdminController to restrict access based on warehouse association instead of role.
- Modified User model to check for warehouse association instead of role for warehouse admin verification.
- Created a new seeder to remove 'WAREHOUSE_ADMIN' role and its permissions from the database.
- Adjusted various views to reflect changes in warehouse role checks.
- Cleaned up routes by removing middleware checks for 'WAREHOUSE_ADMIN' role.
- Updated product creation and editing forms to remove required attributes for warehouse-related fields.